### PR TITLE
Add curvature to CRT shader effect

### DIFF
--- a/Assets/SimpleCRTShader/Editor/CRTPostEffecterEditor.cs
+++ b/Assets/SimpleCRTShader/Editor/CRTPostEffecterEditor.cs
@@ -13,6 +13,8 @@ public class CRTPostEffecterEditor : Editor
         CRTPostEffecter effect = target as CRTPostEffecter;
         effect.material = (Material)EditorGUILayout.ObjectField("Effect Material", effect.material, typeof(Material), false);
 
+        effect.curvatureScale = EditorGUILayout.FloatField("Curvature", effect.curvatureScale);
+
         using (new HorizontalScope(GUI.skin.box))
         {
             effect.whiteNoiseFrequency = EditorGUILayout.IntField("White Noise Freaquency (x/1000)", effect.whiteNoiseFrequency);

--- a/Assets/SimpleCRTShader/Script/CRTPostEffecter.cs
+++ b/Assets/SimpleCRTShader/Script/CRTPostEffecter.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 public class CRTPostEffecter : MonoBehaviour
 {
     public Material material;
+    public float curvatureScale = -0.1f;
     public int whiteNoiseFrequency = 1;
     public float whiteNoiseLength = 0.1f;
     private float whiteNoiseTimeLeft;
@@ -54,6 +55,7 @@ public class CRTPostEffecter : MonoBehaviour
     public Vector2Int resolutions;
 
     #region Properties in shader
+    private int _CurvatureScale;
     private int _WhiteNoiseOnOff;
     private int _ScanlineOnOff;
     private int _MonochormeOnOff;
@@ -83,6 +85,7 @@ public class CRTPostEffecter : MonoBehaviour
 
     private void Start()
     {
+        _CurvatureScale = Shader.PropertyToID("_CurvatureScale");
         _WhiteNoiseOnOff = Shader.PropertyToID("_WhiteNoiseOnOff");
         _ScanlineOnOff = Shader.PropertyToID("_ScanlineOnOff");
         _MonochormeOnOff = Shader.PropertyToID("_MonochormeOnOff");
@@ -126,6 +129,8 @@ public class CRTPostEffecter : MonoBehaviour
             }
         }
         //////
+        
+        material.SetFloat(_CurvatureScale, curvatureScale); 
         
         material.SetInteger(_LetterBoxOnOff, isLetterBox ? 0 : 1); 
         //material.SetInteger(_LetterBoxEdgeBlurOnOff, isLetterBoxEdgeBlur ? 0 : 1); 

--- a/Assets/SimpleCRTShader/material/CRT.mat
+++ b/Assets/SimpleCRTShader/material/CRT.mat
@@ -2,20 +2,24 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!21 &2100000
 Material:
-  serializedVersion: 6
+  serializedVersion: 8
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: CRT
   m_Shader: {fileID: 4800000, guid: fd1d99cddfb7f5644bbd3d844f92ab11, type: 3}
-  m_ShaderKeywords: 
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:


### PR DESCRIPTION
- Add curvature to CRT shader effect
- Also add a 'curvatureScale' property to provides control for the level of curvature simulated by the CRT shader.
- CRT.mat is updated to match Unity 2022.3.


https://github.com/yunoda-3DCG/Simple-CRT-Shader/assets/722132/d5ebd782-a06f-4f3f-b81e-2c7522451979


---
Hey !
At Lonestone we are using your shader for our upcoming game, we wanted some curvature effect on top of other CRT effect so I figured I could share the addition. Thanks for your work on this shader!
